### PR TITLE
File 관련 entity 및 repository 생성

### DIFF
--- a/src/main/java/com/example/tripKo/domain/contents/entity/Contents.java
+++ b/src/main/java/com/example/tripKo/domain/contents/entity/Contents.java
@@ -14,6 +14,8 @@ import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
+
+import com.example.tripKo.domain.file.entity.ContentsFile;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -45,6 +47,9 @@ public class Contents {
 
   @OneToMany(mappedBy = "contents")
   private final List<ContentsMenu> contentsMenus = new ArrayList<>();
+
+  @OneToMany(mappedBy = "contents")
+  private final List<ContentsFile> contentsFiles = new ArrayList<>();
 
   @Builder
   private Contents(Long page, String description, Place place) {

--- a/src/main/java/com/example/tripKo/domain/contents/entity/ContentsMenu.java
+++ b/src/main/java/com/example/tripKo/domain/contents/entity/ContentsMenu.java
@@ -4,7 +4,7 @@ import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
-import com.example.tripKo.domain.File;
+import com.example.tripKo.domain.file.entity.File;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -52,7 +52,7 @@ public class ContentsMenu {
 
   @Builder
   private ContentsMenu(Contents contents, Long price, String name, String description, String characteristic, File file) {
-    this. contents = contents;
+    this.contents = contents;
     this.price = price;
     this.name = name;
     this.description = description;

--- a/src/main/java/com/example/tripKo/domain/file/api/FileController.java
+++ b/src/main/java/com/example/tripKo/domain/file/api/FileController.java
@@ -1,0 +1,4 @@
+package com.example.tripKo.domain.file.api;
+
+public class FileController {
+}

--- a/src/main/java/com/example/tripKo/domain/file/application/FileService.java
+++ b/src/main/java/com/example/tripKo/domain/file/application/FileService.java
@@ -1,0 +1,4 @@
+package com.example.tripKo.domain.file.application;
+
+public class FileService {
+}

--- a/src/main/java/com/example/tripKo/domain/file/dao/ContentsFileRepository.java
+++ b/src/main/java/com/example/tripKo/domain/file/dao/ContentsFileRepository.java
@@ -1,0 +1,8 @@
+package com.example.tripKo.domain.file.dao;
+
+import com.example.tripKo.domain.file.entity.ContentsFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContentsFileRepository extends JpaRepository<ContentsFile, Long> {
+
+}

--- a/src/main/java/com/example/tripKo/domain/file/dao/FileRepository.java
+++ b/src/main/java/com/example/tripKo/domain/file/dao/FileRepository.java
@@ -1,0 +1,8 @@
+package com.example.tripKo.domain.file.dao;
+
+import com.example.tripKo.domain.file.entity.File;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FileRepository extends JpaRepository<File, Long> {
+
+}

--- a/src/main/java/com/example/tripKo/domain/file/entity/ContentsFile.java
+++ b/src/main/java/com/example/tripKo/domain/file/entity/ContentsFile.java
@@ -1,0 +1,46 @@
+package com.example.tripKo.domain.file.entity;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.example.tripKo.domain.contents.entity.Contents;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@DynamicInsert
+@DynamicUpdate
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "contents_has_file")
+public class ContentsFile {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "contents_id", nullable = false)
+    private Contents contents;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "file_id", nullable = false)
+    private File file;
+
+    @Builder
+    private ContentsFile(Contents contents, File file) {
+        this.contents = contents;
+        this.file = file;
+    }
+
+}

--- a/src/main/java/com/example/tripKo/domain/file/entity/File.java
+++ b/src/main/java/com/example/tripKo/domain/file/entity/File.java
@@ -1,0 +1,44 @@
+package com.example.tripKo.domain.file.entity;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import javax.persistence.*;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@DynamicInsert
+@DynamicUpdate
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "file")
+public class File {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long id;
+
+    @Column(nullable = false)
+    private String type;
+
+    @Column(nullable = false)
+    private String name;
+
+    @OneToMany(mappedBy = "file")
+    private List<ContentsFile> contentsFiles = new ArrayList<>();
+
+    @Builder
+    private File(String type, String name) {
+        this.type = type;
+        this.name = name;
+    }
+
+}


### PR DESCRIPTION
## 수행한 작업
File 도메인을 생성하고 `File`와 `Contents File`에 대한 entity를 생성하였습니다.

## 전하고 싶은 내용
- contents file 테이블은 중간 테이블인데 @jointable 사용하지 않고 따로 엔티티를 만드는게 좋을까요? @jointable 방식은 데이터 추가를 못 한다고 알고 있어서요,,!
- ERD에는 따로 contents file 테이블의 고유 id 표시가 안되어 있는데 요즘엔 고유 id 쓰는 비식별 관계를 선호한다고 합니다! 혹시 부모 테이블 id를 그대로 받는게 좋을까요 아님 고유 id를 쓰는게 좋을까요?

