### PR TITLE
Feature/음식 상세정보 불러오기 기능 구현

### DIFF
--- a/src/main/java/com/example/tripKo/_core/utils/TestData.java
+++ b/src/main/java/com/example/tripKo/_core/utils/TestData.java
@@ -1,5 +1,7 @@
 package com.example.tripKo._core.utils;
 
+import com.example.tripKo.domain.food.dao.FoodHasPlaceRestaurantRepository;
+import com.example.tripKo.domain.food.entity.FoodHasPlaceRestaurants;
 import com.example.tripKo.domain.place.dao.AddressCategoryRepository;
 import com.example.tripKo.domain.place.dao.AddressRepository;
 import com.example.tripKo.domain.place.entity.Address;
@@ -54,6 +56,7 @@ public class TestData implements CommandLineRunner {
     private final FoodRepository foodRepository;
     private final FoodContentsRepository foodContentsRepository;
     private final FoodContentsHadFileRepository foodContentsHadFileRepository;
+    private final FoodHasPlaceRestaurantRepository foodHasPlaceRestaurantRepository;
 
 
     @Override
@@ -163,6 +166,20 @@ public class TestData implements CommandLineRunner {
         foods.get(2).updateView();
         foods.get(2).updateView();
 
+        //food 식당 연관 추가
+        List<FoodHasPlaceRestaurants> foodHasPlaceRestaurants = Arrays.asList(
+                FoodHasPlaceRestaurants.builder().placeRestaurant(placeRestaurants.get(0)).food(foods.get(2)).build(),
+                FoodHasPlaceRestaurants.builder().placeRestaurant(placeRestaurants.get(1)).food(foods.get(2)).build()
+        );
+
+        //food 재료 추가
+        foods.get(2).addIngredients("gochujang(red chill paste)");
+        foods.get(2).addIngredients("namul(seasoned vegetables)");
+        foods.get(2).addIngredients("egg");
+        foods.get(2).addIngredients("rice");
+        foods.get(2).addIngredients("meat");
+
+
         foods.get(1).updateView();
         foods.get(1).updateView();
         foods.get(1).updateView();
@@ -183,5 +200,6 @@ public class TestData implements CommandLineRunner {
         foodRepository.saveAll(foods);
         foodContentsRepository.saveAll(foodContentsList);
         foodContentsHadFileRepository.saveAll(foodContentsHasFiles);
+        foodHasPlaceRestaurantRepository.saveAll(foodHasPlaceRestaurants);
     }
 }

--- a/src/main/java/com/example/tripKo/domain/food/api/FoodController.java
+++ b/src/main/java/com/example/tripKo/domain/food/api/FoodController.java
@@ -2,11 +2,13 @@ package com.example.tripKo.domain.food.api;
 
 import com.example.tripKo._core.utils.ApiUtils;
 import com.example.tripKo.domain.food.application.FoodService;
+import com.example.tripKo.domain.food.dto.response.FoodDetailsResponse;
 import com.example.tripKo.domain.food.dto.response.FoodResponse;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,6 +22,13 @@ public class FoodController {
     @GetMapping("/foods")
     public ResponseEntity<?> findByKeyword(@RequestParam(value = "query", defaultValue = "") String query, @RequestParam(value = "sort", defaultValue = "True") String sort) {
         List<FoodResponse> responseDTO = foodService.findByKeyword(query, sort);
+        ApiUtils.ApiResult<?> apiResult = ApiUtils.success(responseDTO);
+        return ResponseEntity.ok(apiResult);
+    }
+
+    @GetMapping("/foods/{foodId}")
+    public ResponseEntity<?> findByFoodId(@PathVariable Long foodId) {
+        FoodDetailsResponse responseDTO = foodService.getFoodInfo(foodId);
         ApiUtils.ApiResult<?> apiResult = ApiUtils.success(responseDTO);
         return ResponseEntity.ok(apiResult);
     }

--- a/src/main/java/com/example/tripKo/domain/food/application/FoodService.java
+++ b/src/main/java/com/example/tripKo/domain/food/application/FoodService.java
@@ -2,10 +2,10 @@ package com.example.tripKo.domain.food.application;
 
 import com.example.tripKo._core.errors.exception.Exception404;
 import com.example.tripKo.domain.food.dao.FoodRepository;
+import com.example.tripKo.domain.food.dto.response.FoodDetailsResponse;
 import com.example.tripKo.domain.food.dto.response.FoodResponse;
 import com.example.tripKo.domain.food.entity.Food;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.annotations.SortComparator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -92,5 +92,13 @@ public class FoodService {
         List<FoodResponse> foodResponses = foodSet.stream().map(f->FoodResponse.builder().food(f).build()).collect(Collectors.toList());
 
         return foodResponses;
+    }
+
+    @Transactional
+    public FoodDetailsResponse getFoodInfo(Long id) {
+        Food food = foodRepository.findById(id)
+                .orElseThrow(() -> new Exception404("해당하는 컨텐츠를 찾을 수 없습니다. id: " + id));
+        FoodDetailsResponse foodDetailsResponse = new FoodDetailsResponse(food);
+        return foodDetailsResponse;
     }
 }

--- a/src/main/java/com/example/tripKo/domain/food/dao/FoodHasPlaceRestaurantRepository.java
+++ b/src/main/java/com/example/tripKo/domain/food/dao/FoodHasPlaceRestaurantRepository.java
@@ -1,0 +1,7 @@
+package com.example.tripKo.domain.food.dao;
+
+import com.example.tripKo.domain.food.entity.FoodHasPlaceRestaurants;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FoodHasPlaceRestaurantRepository extends JpaRepository<FoodHasPlaceRestaurants, Long> {
+}

--- a/src/main/java/com/example/tripKo/domain/food/dto/response/FoodDetailsResponse.java
+++ b/src/main/java/com/example/tripKo/domain/food/dto/response/FoodDetailsResponse.java
@@ -1,0 +1,79 @@
+package com.example.tripKo.domain.food.dto.response;
+
+import com.example.tripKo.domain.food.FoodCategory;
+import com.example.tripKo.domain.food.entity.Food;
+import com.example.tripKo.domain.food.entity.FoodContents;
+import com.example.tripKo.domain.food.entity.FoodHasPlaceRestaurants;
+import com.example.tripKo.domain.place.entity.Address;
+import com.example.tripKo.domain.place.entity.AddressCategory;
+import com.example.tripKo.domain.place.entity.PlaceRestaurant;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class FoodDetailsResponse {
+    private Long foodId;
+    private String name;
+    private FoodCategory category;
+    private List<FoodContentsDTO> contents;
+
+    private List<RestaurantDTO> restaurant;
+    private List<String> ingredients;
+
+    @Getter
+    @Builder
+    public static class FoodContentsDTO {
+        private Long page;
+        private String description;
+        private List<String> images;
+    }
+
+    @Getter
+    @Builder
+    public static class RestaurantDTO {
+        private String name;
+        private String location;
+        private float averageRating;
+    }
+
+    public FoodDetailsResponse(Food food) {
+        this.foodId = food.getId();
+        this.name = food.getName();
+        this.category = food.getFoodCategory();
+        this.contents = food.getFoodContents().stream()
+                .map(this::mapContent)
+                .collect(Collectors.toList());
+        this.restaurant = food.getFoodHasPlaceRestaurants().stream()
+                .map(this::mapRestaurant)
+                .collect(Collectors.toList());
+        this.ingredients = food.getIngredients();
+    }
+
+    private FoodContentsDTO mapContent(FoodContents foodContents) {
+        return FoodContentsDTO.builder()
+                .page(foodContents.getPage())
+                .description(foodContents.getDescription())
+                .images(foodContents.getFoodContentsHasFiles().stream()
+                        .map(fc -> fc.getFile().getName())
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
+    private RestaurantDTO mapRestaurant(FoodHasPlaceRestaurants foodHasPlaceRestaurants) {
+        return RestaurantDTO.builder()
+                .name(foodHasPlaceRestaurants.getPlaceRestaurant().getPlace().getName())
+                .location(addressToString(foodHasPlaceRestaurants.getPlaceRestaurant().getPlace().getAddress()))
+                .averageRating(foodHasPlaceRestaurants.getPlaceRestaurant().getPlace().getAverageRating())
+                .build();
+    }
+
+    private String addressToString(Address address) {
+        String addressToString = address.getBuildingName() + " " + address.getRoadName();
+        AddressCategory addressCategory = address.getAddressCategory();
+        String addressCategoryToString = addressCategory.getEmdName() + " " + addressCategory.getSiggName() + " " + addressCategory.getSidoName();
+        return addressToString + " " + addressCategoryToString;
+    }
+}

--- a/src/main/java/com/example/tripKo/domain/food/dto/response/FoodDetailsResponse.java
+++ b/src/main/java/com/example/tripKo/domain/food/dto/response/FoodDetailsResponse.java
@@ -65,7 +65,7 @@ public class FoodDetailsResponse {
     private RestaurantDTO mapRestaurant(FoodHasPlaceRestaurants foodHasPlaceRestaurants) {
         return RestaurantDTO.builder()
                 .name(foodHasPlaceRestaurants.getPlaceRestaurant().getPlace().getName())
-                .location(addressToString(foodHasPlaceRestaurants.getPlaceRestaurant().getPlace().getAddress()))
+                .location(foodHasPlaceRestaurants.getPlaceRestaurant().getPlace().getAddress().toString())
                 .averageRating(foodHasPlaceRestaurants.getPlaceRestaurant().getPlace().getAverageRating())
                 .build();
     }

--- a/src/main/java/com/example/tripKo/domain/food/entity/Food.java
+++ b/src/main/java/com/example/tripKo/domain/food/entity/Food.java
@@ -44,6 +44,15 @@ public class Food {
     @OneToMany(fetch = LAZY, mappedBy = "food")
     private final List<FoodContents> foodContents = new ArrayList<>();
 
+    @OneToMany(fetch = LAZY, mappedBy = "food")
+    private final List<FoodHasPlaceRestaurants> foodHasPlaceRestaurants = new ArrayList<>();
+
+    @ElementCollection
+    @CollectionTable(name = "food_ingredients", joinColumns = @JoinColumn(name = "food_id"))
+    @Column(name = "ingredients_name")
+    private final List<String> ingredients = new ArrayList<>();
+
+
     @Builder
     public Food(String name, String summary, String keyword, FoodCategory foodCategory, File file) {
         this.name = name;
@@ -57,6 +66,8 @@ public class Food {
     public void addFoodContents(FoodContents foodContents) {
         this.foodContents.add(foodContents);
     }
+
+    public void addIngredients(String ingredients) { this.ingredients.add(ingredients);}
 
     public void updateView() {
         this.view++;

--- a/src/main/java/com/example/tripKo/domain/food/entity/FoodHasPlaceRestaurants.java
+++ b/src/main/java/com/example/tripKo/domain/food/entity/FoodHasPlaceRestaurants.java
@@ -11,6 +11,7 @@ import javax.persistence.*;
 
 import static lombok.AccessLevel.PROTECTED;
 import static javax.persistence.GenerationType.IDENTITY;
+import static javax.persistence.FetchType.LAZY;
 
 @DynamicInsert
 @DynamicUpdate
@@ -24,11 +25,11 @@ public class FoodHasPlaceRestaurants {
     @Column(nullable = false, updatable = false)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "food_id", nullable = false)
     private Food food;
 
-    @ManyToOne
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "place_restaurant_id", nullable = false)
     private PlaceRestaurant placeRestaurant;
 

--- a/src/main/java/com/example/tripKo/domain/food/entity/FoodHasPlaceRestaurants.java
+++ b/src/main/java/com/example/tripKo/domain/food/entity/FoodHasPlaceRestaurants.java
@@ -1,0 +1,40 @@
+package com.example.tripKo.domain.food.entity;
+
+import com.example.tripKo.domain.place.entity.PlaceRestaurant;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import javax.persistence.*;
+
+import static lombok.AccessLevel.PROTECTED;
+import static javax.persistence.GenerationType.IDENTITY;
+
+@DynamicInsert
+@DynamicUpdate
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "food_has_place_restaurants")
+public class FoodHasPlaceRestaurants {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "food_id", nullable = false)
+    private Food food;
+
+    @ManyToOne
+    @JoinColumn(name = "place_restaurant_id", nullable = false)
+    private PlaceRestaurant placeRestaurant;
+
+    @Builder
+    public FoodHasPlaceRestaurants(Food food, PlaceRestaurant placeRestaurant) {
+        this.food = food;
+        this.placeRestaurant = placeRestaurant;
+    }
+}

--- a/src/main/java/com/example/tripKo/domain/place/entity/Address.java
+++ b/src/main/java/com/example/tripKo/domain/place/entity/Address.java
@@ -39,4 +39,11 @@ public class Address extends BaseTimeEntity {
         this.zipCode = zipCode;
         this.addressCategory = addressCategory;
     }
+
+    @Override
+    public String toString() {
+        String addressToString = buildingName + " " + roadName;
+        String addressCategoryToString = addressCategory.getEmdName() + " " + addressCategory.getSiggName() + " " + addressCategory.getSidoName();
+        return addressToString + " " + addressCategoryToString;
+    }
 }


### PR DESCRIPTION
## Issue
#17 

## 수행한 작업
- 음식 상세정보 불러오기 기능 구현

## 전하고 싶은 내용
### 음식 재료 데이터 처리
API 명세서에서 재료를 "Pork belly slices", "Garilc", "Kimchi", "Ssamjang sauce" 처럼 상세한 정보를 요구하여 큰 카테고리로 음식 재료를 저장하는 대신 Food의 Column에 String List 형식으로 재료를 저장하였습니다.

## 실행 결과
```
// http://localhost:8080/foods/3

{
  "success": true,
  "response": {
    "foodId": 3,
    "name": "bibimbap",
    "category": "KOREAN",
    "contents": [
      {
        "page": 0,
        "description": "컨텐츠 설명 0",
        "images": [
          "/image/contentsFood/3"
        ]
      },
      {
        "page": 1,
        "description": "컨텐츠 설명 1",
        "images": [
          "/image/contentsFood/3"
        ]
      }
    ],
    "restaurant": [
      {
        "name": "정문토스트",
        "location": "BuildingName1 RoadName1 GeumjeongGu JangjeonDong Busan",
        "averageRating": 4.4
      },
      {
        "name": "명물토스트",
        "location": "BuildingName2 RoadName2 GeumjeongGu JangjeonDong Busan",
        "averageRating": 4.2
      }
    ],
    "ingredients": [
      "gochujang(red chill paste)",
      "namul(seasoned vegetables)",
      "egg",
      "rice",
      "meat"
    ]
  },
  "error": null
}
```