### PR TITLE
test : restdocs 설정

### DIFF
--- a/src/docs/asciidoc/member/member.adoc
+++ b/src/docs/asciidoc/member/member.adoc
@@ -1,0 +1,24 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+= MEMBER API 문서
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 1
+:sectlinks:
+// 예시
+// == *식당 예약 불러오기*
+//
+// === 요청
+//
+// ==== Request
+//
+// include::{snippets}/get-restaurant-reservation-test/should_success_get_restaurant_reservation_info/http-request.adoc[]
+//
+// === 응답
+//
+// ==== Response
+//
+// include::{snippets}/get-restaurant-reservation-test/should_success_get_restaurant_reservation_info/http-response.adoc[]

--- a/src/docs/asciidoc/place/contents.adoc
+++ b/src/docs/asciidoc/place/contents.adoc
@@ -1,0 +1,10 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+= CONTENTS API 문서
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 1
+:sectlinks:

--- a/src/docs/asciidoc/place/place.adoc
+++ b/src/docs/asciidoc/place/place.adoc
@@ -1,0 +1,10 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+= PLACE API 문서
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 1
+:sectlinks:

--- a/src/test/java/com/example/tripKo/IntegrationTest.java
+++ b/src/test/java/com/example/tripKo/IntegrationTest.java
@@ -1,0 +1,116 @@
+package com.example.tripKo;
+
+import com.example.tripKo.domain.file.dao.FileRepository;
+import com.example.tripKo.domain.member.application.MemberService;
+import com.example.tripKo.domain.member.dao.MemberRepository;
+import com.example.tripKo.domain.member.dao.MemberReservationInfoRepository;
+import com.example.tripKo.domain.place.application.ContentsService;
+import com.example.tripKo.domain.place.application.PlaceService;
+import com.example.tripKo.domain.place.dao.AddressCategoryRepository;
+import com.example.tripKo.domain.place.dao.AddressRepository;
+import com.example.tripKo.domain.place.dao.ContentsMenuRepository;
+import com.example.tripKo.domain.place.dao.ContentsRepository;
+import com.example.tripKo.domain.place.dao.PlaceFestivalRepository;
+import com.example.tripKo.domain.place.dao.PlaceRepository;
+import com.example.tripKo.domain.place.dao.PlaceRestaurantRepository;
+import com.example.tripKo.domain.place.dao.PlaceTouristSpotRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+@ExtendWith({SpringExtension.class, RestDocumentationExtension.class})
+@Transactional
+@SpringBootTest
+public class IntegrationTest {
+
+  /*** repository ***/
+  @SpyBean
+  protected ContentsRepository contentsRepository;
+
+  @SpyBean
+  protected ContentsMenuRepository contentsMenuRepository;
+
+  @SpyBean
+  protected PlaceFestivalRepository placeFestivalRepository;
+
+  @SpyBean
+  protected PlaceRestaurantRepository placeRestaurantRepository;
+
+  @SpyBean
+  protected PlaceTouristSpotRepository placeTouristSpotRepository;
+
+  @SpyBean
+  protected PlaceRepository placeRepository;
+
+  @SpyBean
+  protected FileRepository fileRepository;
+
+  @SpyBean
+  protected AddressRepository addressRepository;
+
+  @SpyBean
+  protected AddressCategoryRepository addressCategoryRepository;
+
+  @SpyBean
+  protected MemberRepository memberRepository;
+
+  @SpyBean
+  protected MemberReservationInfoRepository memberReservationInfoRepository;
+
+
+  /*** service ***/
+  @Autowired
+  protected ContentsService contentsService;
+
+  @Autowired
+  protected PlaceService placeService;
+
+  @Autowired
+  protected MemberService memberService;
+
+
+  /*** Spring Bean ***/
+  @Autowired
+  protected WebApplicationContext webApplicationContext;
+
+  @Autowired
+  protected ObjectMapper objectMapper;
+
+  @PersistenceContext
+  protected EntityManager em;
+
+  protected MockMvc mockMvc;
+
+  protected RestDocumentationResultHandler document;
+
+  @BeforeEach
+  protected void setUpAll(WebApplicationContext webApplicationContext,
+      RestDocumentationContextProvider restDocumentation) {
+    this.document = MockMvcRestDocumentation.document("{class-name}/{method-name}",
+        Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+        Preprocessors.preprocessResponse(Preprocessors.prettyPrint()));
+
+    this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+        .addFilter(new CharacterEncodingFilter("UTF-8", true))
+        .apply(MockMvcRestDocumentation.documentationConfiguration(restDocumentation))
+        .alwaysDo(document)
+        .build();
+  }
+
+}

--- a/src/test/java/com/example/tripKo/domain/food/api/FoodControllerTest.java
+++ b/src/test/java/com/example/tripKo/domain/food/api/FoodControllerTest.java
@@ -1,0 +1,10 @@
+package com.example.tripKo.domain.food.api;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+import com.example.tripKo.IntegrationTest;
+
+public class FoodControllerTest extends IntegrationTest {
+
+}

--- a/src/test/java/com/example/tripKo/domain/food/application/FoodServiceTest.java
+++ b/src/test/java/com/example/tripKo/domain/food/application/FoodServiceTest.java
@@ -1,0 +1,9 @@
+package com.example.tripKo.domain.food.application;
+
+import com.example.tripKo.IntegrationTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FoodServiceTest extends IntegrationTest {
+
+}

--- a/src/test/java/com/example/tripKo/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/com/example/tripKo/domain/member/api/MemberControllerTest.java
@@ -1,0 +1,10 @@
+package com.example.tripKo.domain.member.api;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+import com.example.tripKo.IntegrationTest;
+
+public class MemberControllerTest extends IntegrationTest {
+
+}

--- a/src/test/java/com/example/tripKo/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/example/tripKo/domain/member/application/MemberServiceTest.java
@@ -1,0 +1,9 @@
+package com.example.tripKo.domain.member.application;
+
+import com.example.tripKo.IntegrationTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MemberServiceTest extends IntegrationTest {
+
+}

--- a/src/test/java/com/example/tripKo/domain/place/api/ContentsControllerTest.java
+++ b/src/test/java/com/example/tripKo/domain/place/api/ContentsControllerTest.java
@@ -1,0 +1,10 @@
+package com.example.tripKo.domain.place.api;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+import com.example.tripKo.IntegrationTest;
+
+public class ContentsControllerTest extends IntegrationTest {
+
+}

--- a/src/test/java/com/example/tripKo/domain/place/api/PlaceControllerTest.java
+++ b/src/test/java/com/example/tripKo/domain/place/api/PlaceControllerTest.java
@@ -1,0 +1,11 @@
+package com.example.tripKo.domain.place.api;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+import com.example.tripKo.IntegrationTest;
+
+public class PlaceControllerTest extends IntegrationTest {
+
+
+}

--- a/src/test/java/com/example/tripKo/domain/place/application/ContentsServiceTest.java
+++ b/src/test/java/com/example/tripKo/domain/place/application/ContentsServiceTest.java
@@ -1,0 +1,9 @@
+package com.example.tripKo.domain.place.application;
+
+import com.example.tripKo.IntegrationTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ContentsServiceTest extends IntegrationTest {
+
+}

--- a/src/test/java/com/example/tripKo/domain/place/application/PlaceServiceTest.java
+++ b/src/test/java/com/example/tripKo/domain/place/application/PlaceServiceTest.java
@@ -1,0 +1,9 @@
+package com.example.tripKo.domain.place.application;
+
+import com.example.tripKo.IntegrationTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PlaceServiceTest extends IntegrationTest {
+
+}


### PR DESCRIPTION
## ⭐️ Issue
close : 없음


## ⭐️ 수행한 작업
- `restdocs` 설정 및 기타 문서 & 테스트 설정


## ⭐️ 기타
- 헷갈릴 수 있는 import 들은 지우지 않고 그대로 두었습니다.
- `ControllerTest` 와 `ServiceTest` 는 `IntegrationTest` 를 상속 받아서 사용하시면 됩니다~ (지금 만들어져 있는 것들은 다 적용되어 있음)
- `adoc` 파일 부분은 주석처리해서 제가 했던 예시 하나 남겨두었습니다! 
   - 다음 pr 때 주석 처리된 부분은 삭제하겠습니다
- `Controller` 에서 test 하실 때 문서 나오도록 하려면 다음과 같이 작성하시면 됩니다.

**<예시>**
``` java
......
      mockMvc.perform(get("/userinfo/reservations/restaurant"))
          .andExpect(status().isOk())
          .andDo(MockMvcResultHandlers.print())
          .andDo(document);
```