### PR TITLE
Feature/리뷰 작성, 리스트 불러오기 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+src/main/resources/reviews/

--- a/src/main/java/com/example/tripKo/domain/place/PlaceType.java
+++ b/src/main/java/com/example/tripKo/domain/place/PlaceType.java
@@ -1,0 +1,13 @@
+package com.example.tripKo.domain.place;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum PlaceType {
+    RESTAURANT(1),
+    FESTIVAL(2),
+    TOURIST_SPOT(3);
+
+
+    private final long id;
+}

--- a/src/main/java/com/example/tripKo/domain/place/api/ReviewController.java
+++ b/src/main/java/com/example/tripKo/domain/place/api/ReviewController.java
@@ -5,6 +5,7 @@ import com.example.tripKo._core.utils.ApiUtils;
 import com.example.tripKo.domain.member.dao.MemberRepository;
 import com.example.tripKo.domain.member.entity.Member;
 import com.example.tripKo.domain.place.application.ReviewService;
+import com.example.tripKo.domain.place.dto.response.review.ReviewsResponse;
 import com.example.tripKo.domain.place.dto.response.search.PlaceResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -23,14 +24,21 @@ public class ReviewController {
     private final ReviewService reviewService;
     private final MemberRepository memberRepository;
     @PostMapping(path ="/restaurant/reviews", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
-    public ResponseEntity<?> createReview(/*@AuthenticationPrincipal MyUserDetails userDetails, */ @ModelAttribute @Valid ReviewRequest reviewRequest) {
+    public ResponseEntity<?> createPlaceRestaurantReview(/*@AuthenticationPrincipal MyUserDetails userDetails, */ @ModelAttribute @Valid ReviewRequest reviewRequest) {
         //Spring Security 개발되면 삭제
         //원래 userDetails에서 Member를 가져오므로 현재 userDetails에서 Member를 가져왔다고 가정합니다.
         Member member = memberRepository.findById(reviewRequest.getMemberId()).orElseThrow(() -> new Exception404("해당 id를 가진 회원을 찾을 수 없습니다: " + reviewRequest.getMemberId()));
         //Member member = userDetails.getMember()
 
-        reviewService.createReview(reviewRequest, member);
+        reviewService.createPlaceRestaurantReview(reviewRequest, member);
         ApiUtils.ApiResult<?> apiResult = ApiUtils.success(null);
+        return ResponseEntity.ok(apiResult);
+    }
+
+    @GetMapping("/restaurant/reviews/{placeRestaurantId}")
+    public ResponseEntity<?> getPlaceRestaurantReviews(@PathVariable Long placeRestaurantId, @RequestParam(value = "page", defaultValue = "0") Integer page) {
+        ReviewsResponse response = reviewService.getPlaceRestaurantReviewsByPlaceRestaurantId(placeRestaurantId, page);
+        ApiUtils.ApiResult<?> apiResult = ApiUtils.success(response);
         return ResponseEntity.ok(apiResult);
     }
 }

--- a/src/main/java/com/example/tripKo/domain/place/api/ReviewController.java
+++ b/src/main/java/com/example/tripKo/domain/place/api/ReviewController.java
@@ -1,0 +1,36 @@
+package com.example.tripKo.domain.place.api;
+
+import com.example.tripKo._core.errors.exception.Exception404;
+import com.example.tripKo._core.utils.ApiUtils;
+import com.example.tripKo.domain.member.dao.MemberRepository;
+import com.example.tripKo.domain.member.entity.Member;
+import com.example.tripKo.domain.place.application.ReviewService;
+import com.example.tripKo.domain.place.dto.response.search.PlaceResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.example.tripKo.domain.place.dto.request.ReviewRequest;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Size;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class ReviewController {
+    private final ReviewService reviewService;
+    private final MemberRepository memberRepository;
+    @PostMapping(path ="/restaurant/reviews", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<?> createReview(/*@AuthenticationPrincipal MyUserDetails userDetails, */ @ModelAttribute @Valid ReviewRequest reviewRequest) {
+        //Spring Security 개발되면 삭제
+        //원래 userDetails에서 Member를 가져오므로 현재 userDetails에서 Member를 가져왔다고 가정합니다.
+        Member member = memberRepository.findById(reviewRequest.getMemberId()).orElseThrow(() -> new Exception404("해당 id를 가진 회원을 찾을 수 없습니다: " + reviewRequest.getMemberId()));
+        //Member member = userDetails.getMember()
+
+        reviewService.createReview(reviewRequest, member);
+        ApiUtils.ApiResult<?> apiResult = ApiUtils.success(null);
+        return ResponseEntity.ok(apiResult);
+    }
+}

--- a/src/main/java/com/example/tripKo/domain/place/application/ReviewService.java
+++ b/src/main/java/com/example/tripKo/domain/place/application/ReviewService.java
@@ -1,10 +1,18 @@
 package com.example.tripKo.domain.place.application;
 
 import com.example.tripKo._core.errors.exception.Exception400;
+import com.example.tripKo._core.errors.exception.Exception404;
 import com.example.tripKo._core.errors.exception.Exception500;
+import com.example.tripKo.domain.file.dao.FileRepository;
 import com.example.tripKo.domain.member.entity.Member;
+import com.example.tripKo.domain.place.dao.PlaceRepository;
+import com.example.tripKo.domain.place.dao.PlaceRestaurantRepository;
+import com.example.tripKo.domain.place.dao.ReviewFileRepository;
 import com.example.tripKo.domain.place.dao.ReviewRepository;
 import com.example.tripKo.domain.place.dto.request.ReviewRequest;
+import com.example.tripKo.domain.place.entity.Place;
+import com.example.tripKo.domain.place.entity.PlaceRestaurant;
+import com.example.tripKo.domain.place.entity.Review;
 import com.example.tripKo.domain.place.entity.ReviewHasFile;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,6 +21,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -22,11 +32,70 @@ import java.util.Objects;
 @Service
 public class ReviewService {
     private final ReviewRepository reviewRepository;
+    private final FileRepository fileRepository;
+    private final PlaceRestaurantRepository placeRestaurantRepository;
+    private final ReviewFileRepository reviewFileRepository;
 
+    @Transactional
     public void createReview(ReviewRequest reviewRequest, Member member) {
-        saveImages(reviewRequest.getImages());
+        //API에서는 placeId로 되어 있는데 placeRestaurantId으로 받아야 할 것 같다.
+        //리뷰에 저장할 placeRestaurant을 가져오는 부분
+        Long placeRestaurantId = reviewRequest.getPlaceId();
+        PlaceRestaurant placeRestaurant = placeRestaurantRepository.findById(reviewRequest.getPlaceId())
+                .orElseThrow(() -> new Exception404("해당하는 식당을 찾을 수 없습니다. id : " + placeRestaurantId));
 
+        //usageDate는 일단 review를 작성한 날짜로 하였다. 나중에 로직 수정 필요
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd");
+        String usageDate = LocalDate.now().format(formatter);
+
+        //같은 날짜에 동일한 가게를 리뷰했었다면 더이상 리뷰 작성 불가능
+        Review sameReview = reviewRepository.findReviewByMemberIdAndPlaceIdAndUsageDate(reviewRequest.getMemberId(), placeRestaurant.getPlace().getId(), usageDate);
+        if (!Objects.isNull(sameReview)) throw new Exception400("이미 작성한 리뷰가 존재합니다.");
+
+        Review review = Review.builder()
+                .placeRestaurant(placeRestaurant)
+                .member(member)
+                .score(reviewRequest.getRating())
+                .description(reviewRequest.getDescription())
+                .build();
+
+        reviewRepository.save(review);
+
+        //리뷰에 이미지가 있다면 이미지를 리소스 폴더에 저장하고 정보를 File 테이블에 저장
+        if (!reviewRequest.getImages().isEmpty()) {
+            List<com.example.tripKo.domain.file.entity.File> fileEntities = saveImages(reviewRequest.getImages());
+
+            List<ReviewHasFile> reviewHasFiles = createReviewHasFile(fileEntities, review);
+
+            fileRepository.saveAll(fileEntities);
+            reviewFileRepository.saveAll(reviewHasFiles);
+        }
+
+        //업데이트 된 평균 별점 저장
+        Place place = placeRestaurant.getPlace();
+
+        int reviewNumbers = place.getReviewNumbers();
+        float average = place.getAverageRating();
+
+        //실수 -> 정수 과정에서 데이터가 손실될 지 걱정딘다.
+        average = ((float)reviewRequest.getRating() + average * reviewNumbers) / (reviewNumbers + 1);
+        place.setReviewNumbers(reviewNumbers + 1);
+        place.setAverageRating(average);
+
+        placeRestaurantRepository.save(placeRestaurant);
     }
+
+    private List<ReviewHasFile> createReviewHasFile(List<com.example.tripKo.domain.file.entity.File> fileEntities, Review review) {
+        List<ReviewHasFile> reviewHasFiles = new ArrayList<>();
+
+        for (com.example.tripKo.domain.file.entity.File fileEntity : fileEntities) {
+            reviewHasFiles.add(ReviewHasFile.builder().review(review).file(fileEntity).build());
+        }
+
+        return reviewHasFiles;
+    }
+
+
 
     private List<com.example.tripKo.domain.file.entity.File> saveImages(List<MultipartFile> images) {
         List<com.example.tripKo.domain.file.entity.File> fileEntities = new ArrayList<>();
@@ -40,6 +109,7 @@ public class ReviewService {
 
         File imageFile = new File(imagesPath);
 
+        //resources/revew/images에 디렉토리 생성
         if (!imageFile.exists()) {
             boolean isExists = imageFile.mkdirs();
             if (!isExists) {
@@ -52,6 +122,7 @@ public class ReviewService {
             String imageName = image.getOriginalFilename();
             String fileExtension;
 
+            //jpeg, jpg, png만 허용
             if (Objects.isNull(contentType)) {
                 throw new Exception400("올바르지 않은 파일 확장자 형식입니다.");
             }

--- a/src/main/java/com/example/tripKo/domain/place/application/ReviewService.java
+++ b/src/main/java/com/example/tripKo/domain/place/application/ReviewService.java
@@ -1,0 +1,87 @@
+package com.example.tripKo.domain.place.application;
+
+import com.example.tripKo._core.errors.exception.Exception400;
+import com.example.tripKo._core.errors.exception.Exception500;
+import com.example.tripKo.domain.member.entity.Member;
+import com.example.tripKo.domain.place.dao.ReviewRepository;
+import com.example.tripKo.domain.place.dto.request.ReviewRequest;
+import com.example.tripKo.domain.place.entity.ReviewHasFile;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class ReviewService {
+    private final ReviewRepository reviewRepository;
+
+    public void createReview(ReviewRequest reviewRequest, Member member) {
+        saveImages(reviewRequest.getImages());
+
+    }
+
+    private List<com.example.tripKo.domain.file.entity.File> saveImages(List<MultipartFile> images) {
+        List<com.example.tripKo.domain.file.entity.File> fileEntities = new ArrayList<>();
+
+        String imagesPath = new File("").getAbsolutePath() + File.separator
+                + "src" + File.separator
+                + "main" + File.separator
+                + "resources" + File.separator
+                + "reviews" + File.separator
+                + "images";
+
+        File imageFile = new File(imagesPath);
+
+        if (!imageFile.exists()) {
+            boolean isExists = imageFile.mkdirs();
+            if (!isExists) {
+                throw new Exception500("경로 생성에 실패하였습니다.");
+            }
+        }
+
+        for (MultipartFile image : images) {
+            String contentType = image.getContentType();
+            String imageName = image.getOriginalFilename();
+            String fileExtension;
+
+            if (Objects.isNull(contentType)) {
+                throw new Exception400("올바르지 않은 파일 확장자 형식입니다.");
+            }
+            else if (contentType.contains("image/jpeg") ||
+                    contentType.contains("image/jpg"))
+                fileExtension = ".jpg";
+            else if (contentType.contains("image/png"))
+                fileExtension = ".png";
+            else throw new Exception400("올바르지 않은 파일 확장자 형식입니다.");
+
+            String newFileName = String.format("%1$016x",System.nanoTime()) + "_" + imageName;
+            System.out.println("====================");
+            System.out.println(newFileName);
+
+            com.example.tripKo.domain.file.entity.File fileEntity = com.example.tripKo.domain.file.entity.File.builder()
+                    .type(contentType)
+                    .name(newFileName)
+                    .build();
+
+            fileEntities.add(fileEntity);
+
+            String imagePath = imagesPath + File.separator + newFileName;
+            File savedImage = new File(imagePath);
+            try {
+                image.transferTo(savedImage);
+            } catch (IOException e) {
+                throw new Exception500("이미지를 저장하는 중 문제가 발생하였습니다.");
+            }
+        }
+
+        return fileEntities;
+    }
+}

--- a/src/main/java/com/example/tripKo/domain/place/dao/ReviewFileRepository.java
+++ b/src/main/java/com/example/tripKo/domain/place/dao/ReviewFileRepository.java
@@ -1,0 +1,7 @@
+package com.example.tripKo.domain.place.dao;
+
+import com.example.tripKo.domain.place.entity.ReviewHasFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewFileRepository extends JpaRepository<ReviewHasFile, Long>{
+}

--- a/src/main/java/com/example/tripKo/domain/place/dao/ReviewRepository.java
+++ b/src/main/java/com/example/tripKo/domain/place/dao/ReviewRepository.java
@@ -3,9 +3,12 @@ package com.example.tripKo.domain.place.dao;
 import com.example.tripKo.domain.member.entity.Member;
 import com.example.tripKo.domain.place.entity.Place;
 import com.example.tripKo.domain.place.entity.Review;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query("select r from Review r where r.member.id = :memberId" +
@@ -14,4 +17,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     Review findReviewByMemberIdAndPlaceIdAndUsageDate(@Param("memberId") Long memberId,
                                                   @Param("placeId") Long placeId,
                                                   @Param("usageDate") String usageDate);
+
+    @Query(value = "select r from Review r where r.place.id = :placeId",
+            countQuery = "SELECT COUNT(*) FROM PlaceRestaurant")
+    List<Review> findAllByPlaceId(@Param("placeId") Long placeId, Pageable pageable);
 }

--- a/src/main/java/com/example/tripKo/domain/place/dao/ReviewRepository.java
+++ b/src/main/java/com/example/tripKo/domain/place/dao/ReviewRepository.java
@@ -1,0 +1,7 @@
+package com.example.tripKo.domain.place.dao;
+
+import com.example.tripKo.domain.place.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+}

--- a/src/main/java/com/example/tripKo/domain/place/dao/ReviewRepository.java
+++ b/src/main/java/com/example/tripKo/domain/place/dao/ReviewRepository.java
@@ -1,7 +1,17 @@
 package com.example.tripKo.domain.place.dao;
 
+import com.example.tripKo.domain.member.entity.Member;
+import com.example.tripKo.domain.place.entity.Place;
 import com.example.tripKo.domain.place.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+    @Query("select r from Review r where r.member.id = :memberId" +
+            " and r.place.id = :placeId" +
+            " and r.usageDate = :usageDate")
+    Review findReviewByMemberIdAndPlaceIdAndUsageDate(@Param("memberId") Long memberId,
+                                                  @Param("placeId") Long placeId,
+                                                  @Param("usageDate") String usageDate);
 }

--- a/src/main/java/com/example/tripKo/domain/place/dto/request/ReviewRequest.java
+++ b/src/main/java/com/example/tripKo/domain/place/dto/request/ReviewRequest.java
@@ -1,0 +1,34 @@
+package com.example.tripKo.domain.place.dto.request;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+public class ReviewRequest {
+    @NotNull
+    private Long placeId;
+
+    @NotNull
+    private Long memberId; //Spring Security 개발되면 삭제
+
+    @NotNull
+    private int rating;
+
+    private String description;
+
+    @Size(max = 10)
+    List<MultipartFile> images = new ArrayList<>();
+
+}

--- a/src/main/java/com/example/tripKo/domain/place/dto/request/ReviewRequest.java
+++ b/src/main/java/com/example/tripKo/domain/place/dto/request/ReviewRequest.java
@@ -30,5 +30,4 @@ public class ReviewRequest {
 
     @Size(max = 10)
     List<MultipartFile> images = new ArrayList<>();
-
 }

--- a/src/main/java/com/example/tripKo/domain/place/dto/response/review/ReviewsResponse.java
+++ b/src/main/java/com/example/tripKo/domain/place/dto/response/review/ReviewsResponse.java
@@ -1,0 +1,62 @@
+package com.example.tripKo.domain.place.dto.response.review;
+
+import com.example.tripKo.domain.place.entity.Place;
+import com.example.tripKo.domain.place.entity.Review;
+import com.example.tripKo.domain.place.entity.ReviewHasFile;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class ReviewsResponse {
+    @Builder
+    @Getter
+    static class ReviewDTO {
+        private Long reviewId;
+        private Long placeId;
+        private String visitTime;
+        private int rating;
+        private String description;
+        private String nickName;
+        private List<String> images = new ArrayList<>();
+    }
+
+    private float averageRating;
+    private List<ReviewDTO> reviews = new ArrayList<>();
+
+    public ReviewsResponse(List<Review> reviewEntities, Place place) {
+        this.averageRating = place.getAverageRating();
+
+        reviews = reviewEntities.stream()
+                .map(this::mapReview)
+                .collect(Collectors.toList());
+    }
+
+    private ReviewDTO mapReview(Review review) {
+        return ReviewDTO.builder()
+                .reviewId(review.getId())
+                .placeId(review.getPlace().getId())
+                .visitTime(review.getUsageDate())
+                .rating(review.getScore())
+                .description(review.getDescription())
+                .nickName(review.getMember().getNickName())
+                .images(review.getReviewHasFiles().stream()
+                        .map(r -> createFileNameWithPaths(r.getFile().getName()))
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
+    private String createFileNameWithPaths(String filename) {
+        return "src" + File.separator
+                + "main" + File.separator
+                + "resources" + File.separator
+                + "reviews" + File.separator
+                + "images" + File.separator
+                + filename;
+    }
+
+}

--- a/src/main/java/com/example/tripKo/domain/place/entity/Contents.java
+++ b/src/main/java/com/example/tripKo/domain/place/entity/Contents.java
@@ -55,6 +55,8 @@ public class Contents extends BaseTimeEntity {
     this.page = page;
     this.description = description;
     this.place = place;
+
+    place.addContents(this);
   }
 
   //테스트용

--- a/src/main/java/com/example/tripKo/domain/place/entity/Place.java
+++ b/src/main/java/com/example/tripKo/domain/place/entity/Place.java
@@ -49,6 +49,8 @@ public class Place extends BaseTimeEntity {
     @OneToMany(mappedBy = "place")
     private final List<MemberReservationInfo> memberReservationInfos = new ArrayList<>();
 
+    private int reviewNumbers;
+
     @Builder
     public Place(String name, String summary, int count, float averageRating, File file, Address address) {
         this.name = name;
@@ -70,4 +72,11 @@ public class Place extends BaseTimeEntity {
         return addressToString + " " + addressCategoryToString;
     }
 
+    public void setAverageRating(float averageRating) {
+        this.averageRating = averageRating;
+    }
+
+    public void setReviewNumbers(int reviewNumbers) {
+        this.reviewNumbers = reviewNumbers;
+    }
 }

--- a/src/main/java/com/example/tripKo/domain/place/entity/Review.java
+++ b/src/main/java/com/example/tripKo/domain/place/entity/Review.java
@@ -1,0 +1,51 @@
+package com.example.tripKo.domain.place.entity;
+
+import com.example.tripKo.domain.member.entity.Member;
+import com.example.tripKo.domain.place.PlaceType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import javax.persistence.*;
+
+import static lombok.AccessLevel.PROTECTED;
+import static javax.persistence.GenerationType.IDENTITY;
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.EnumType.STRING;
+
+@DynamicInsert
+@DynamicUpdate
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "review")
+public class Review {
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false, updatable = false)
+    @Id
+    private Long id;
+
+    @Column(nullable = false)
+    private Float score;
+
+    private String description;
+
+    @Column(nullable = false)
+    private String usage_date;
+
+    @ManyToOne(fetch = LAZY)
+    @Column(name = "member", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = LAZY)
+    @Column(name = "place", nullable = false)
+    private Place place;
+
+    @Column(nullable = false)
+    private boolean isAvailable;
+
+    @Enumerated(value = STRING)
+    @Column(nullable = false)
+    private PlaceType type;
+}

--- a/src/main/java/com/example/tripKo/domain/place/entity/Review.java
+++ b/src/main/java/com/example/tripKo/domain/place/entity/Review.java
@@ -12,6 +12,8 @@ import javax.persistence.*;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 
 import static lombok.AccessLevel.PROTECTED;
 import static javax.persistence.GenerationType.IDENTITY;
@@ -53,6 +55,9 @@ public class Review {
     @Column(nullable = false)
     private PlaceType type;
 
+    @OneToMany(mappedBy = "review")
+    private List<ReviewHasFile> reviewHasFiles = new ArrayList<>();
+
     @Builder
     public Review(PlaceRestaurant placeRestaurant, Member member, String description, int score) {
         this.type = PlaceType.RESTAURANT;
@@ -60,6 +65,8 @@ public class Review {
         this.member = member;
         this.description = description;
         this.score = score;
+
+        //일단 방문 날짜를 리뷰 작성 날짜로 하였다.
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd");
         this.usageDate = LocalDate.now().format(formatter);
     }

--- a/src/main/java/com/example/tripKo/domain/place/entity/Review.java
+++ b/src/main/java/com/example/tripKo/domain/place/entity/Review.java
@@ -27,7 +27,7 @@ public class Review {
     private Long id;
 
     @Column(nullable = false)
-    private Float score;
+    private int score;//float가 아니라 int가 되야한다.
 
     private String description;
 
@@ -35,11 +35,11 @@ public class Review {
     private String usage_date;
 
     @ManyToOne(fetch = LAZY)
-    @Column(name = "member", nullable = false)
+    @JoinColumn(name = "member", nullable = false)
     private Member member;
 
     @ManyToOne(fetch = LAZY)
-    @Column(name = "place", nullable = false)
+    @JoinColumn(name = "place", nullable = false)
     private Place place;
 
     @Column(nullable = false)
@@ -48,4 +48,12 @@ public class Review {
     @Enumerated(value = STRING)
     @Column(nullable = false)
     private PlaceType type;
+
+    public Review(PlaceRestaurant placeRestaurant, Member member, String description, int score) {
+        this.type = PlaceType.RESTAURANT;
+        this.place = placeRestaurant.getPlace();
+        this.member = member;
+        this.description = description;
+        this.score = score;
+    }
 }

--- a/src/main/java/com/example/tripKo/domain/place/entity/Review.java
+++ b/src/main/java/com/example/tripKo/domain/place/entity/Review.java
@@ -2,12 +2,16 @@ package com.example.tripKo.domain.place.entity;
 
 import com.example.tripKo.domain.member.entity.Member;
 import com.example.tripKo.domain.place.PlaceType;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.*;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 import static lombok.AccessLevel.PROTECTED;
 import static javax.persistence.GenerationType.IDENTITY;
@@ -32,7 +36,7 @@ public class Review {
     private String description;
 
     @Column(nullable = false)
-    private String usage_date;
+    private String usageDate;
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "member", nullable = false)
@@ -49,11 +53,14 @@ public class Review {
     @Column(nullable = false)
     private PlaceType type;
 
+    @Builder
     public Review(PlaceRestaurant placeRestaurant, Member member, String description, int score) {
         this.type = PlaceType.RESTAURANT;
         this.place = placeRestaurant.getPlace();
         this.member = member;
         this.description = description;
         this.score = score;
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd");
+        this.usageDate = LocalDate.now().format(formatter);
     }
 }

--- a/src/main/java/com/example/tripKo/domain/place/entity/ReviewHasFile.java
+++ b/src/main/java/com/example/tripKo/domain/place/entity/ReviewHasFile.java
@@ -1,0 +1,41 @@
+package com.example.tripKo.domain.place.entity;
+
+import com.example.tripKo.domain.file.entity.File;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import javax.persistence.*;
+
+import static lombok.AccessLevel.PROTECTED;
+import static javax.persistence.GenerationType.IDENTITY;
+import static javax.persistence.FetchType.LAZY;
+
+@DynamicInsert
+@DynamicUpdate
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "review_has_file")
+public class ReviewHasFile {
+    @GeneratedValue(strategy = IDENTITY)
+    @Id
+    @Column(nullable = false, updatable = false)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "review_id", nullable = false)
+    private Review review;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "file_id", nullable = false)
+    private File file;
+
+    @Builder
+    public ReviewHasFile(Review review, File file){
+        this.review = review;
+        this.file = file;
+    }
+}

--- a/src/main/java/com/example/tripKo/domain/place/entity/ReviewHasFile.java
+++ b/src/main/java/com/example/tripKo/domain/place/entity/ReviewHasFile.java
@@ -37,5 +37,7 @@ public class ReviewHasFile {
     public ReviewHasFile(Review review, File file){
         this.review = review;
         this.file = file;
+
+        review.getReviewHasFiles().add(this);
     }
 }

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -6,3 +6,8 @@ spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=create
 Spring.jpa.properties.hibernate.default_batch_fetch_size=10
 spring.jpa.properties.hibernate.format_sql=true
+
+spring.servlet.multipart.file-size-threshold=1MB
+spring.servlet.multipart.location= C:/temp
+spring.servlet.multipart.max-file-size= 10MB
+spring.servlet.multipart.max-request-size= 100MB


### PR DESCRIPTION
## Issue
#32 
#35 


## 수행한 작업
- Review, ReviewHasFile 엔티티 및 레포지토리 생성
- form-data로 전송된 이미지 프로젝트에 저장
- 식당 리뷰 작성 기능 구현
- 식당 리뷰 불러오기 기능 구현


## 전하고 싶은 내용
### Java File 클래스와 File 엔티티의 중복
현재 자바의 File 클래스와 File 엔티티가 이름이 같아서 File 엔티티를 패키지 이름 다 붙여서 사용하고 있습니다. File 엔티티의 이름을 변경하면 좋을 것 같습니다.


### 이미지 저장
이미지 저장은 resource 폴더 하위에 저장되도록 하였고 다른 사용자가 이미지 이름을 중복해서 올릴 수 있도록 이미지 앞에 시스템 시간을 붙여 이름을 저장하였습니다. 이미지는 jpeg, jpg, png 형식만 받도록 하였습니다.
저장 경로를 변경할 때는 ReviewService의 saveImages 메서드와 ReviewResponse의 createFileNameWithPaths 메서드 두 개를 수정해야 합니다.


### 설계 수정
Review의 Score는 float에서 int로 수정하여 작성하였고 API 명세에서 입력을 받을 때도 placeId가 아닌 placeRestaurantId를 받아서 작동하도록 구현하였습니다.


### 리팩토링 필요
현재 로그인을 통한 회원 기능이 개발되어 있지 않아 Review의 방문 일자, userDetails에서 Member 가져오기는 추후 리팩토링 필요합니다.


## 실행 결과
### 리뷰 생성
![리뷰 생성](https://github.com/Step3-kakao-tech-campus/Team6_BE/assets/83940605/19976b76-ae72-4a42-a0f0-b0a670a827b2)


### 이미지 저장 결과
![이미지 저장](https://github.com/Step3-kakao-tech-campus/Team6_BE/assets/83940605/84761abc-a957-4a13-ae8f-3b9d8e4bf07f)


### 리뷰 리스트 가져오기
![리뷰 불러오기](https://github.com/Step3-kakao-tech-campus/Team6_BE/assets/83940605/5decf635-8f22-44a9-88bf-c8a1de6ef5a8)



