### PR TITLE
Feature/Festival 리뷰 CRUD 개발과 그 외 수정사항

### DIFF
--- a/src/main/java/com/example/tripKo/_core/utils/TestData.java
+++ b/src/main/java/com/example/tripKo/_core/utils/TestData.java
@@ -5,6 +5,7 @@ import com.example.tripKo.domain.member.dao.MemberRepository;
 import com.example.tripKo.domain.member.entity.Member;
 import com.example.tripKo.domain.food.dao.FoodHasPlaceRestaurantRepository;
 import com.example.tripKo.domain.food.entity.FoodHasPlaceRestaurants;
+import com.example.tripKo.domain.place.PlaceType;
 import com.example.tripKo.domain.place.dao.AddressCategoryRepository;
 import com.example.tripKo.domain.place.dao.AddressRepository;
 import com.example.tripKo.domain.place.entity.Address;
@@ -112,12 +113,12 @@ public class TestData implements CommandLineRunner {
         addressRepository.saveAll(addresses);
 
         List<Place> places = Arrays.asList(
-                Place.builder().name("정문토스트").summary("정문토스트는..").count(100).averageRating((float)4.4).address(addresses.get(0)).file(files.get(0)).build(),
-                Place.builder().name("명물토스트").summary("명물토스트는..").count(200).averageRating((float)4.2).address(addresses.get(1)).file(files.get(1)).build(),
-                Place.builder().name("2023 부산 국제 락 페스티벌").summary("부락페는..").count(300).averageRating((float)4.3).address(addresses.get(2)).file(files.get(3)).build(),
-                Place.builder().name("2023 대동제").summary("대동제는..").count(200).averageRating((float)4.0).address(addresses.get(0)).file(files.get(3)).build(),
-                Place.builder().name("Signiel Busan").summary("부산 시그니엘은..").count(100).averageRating((float)4.5).address(addresses.get(4)).file(files.get(6)).build(),
-                Place.builder().name("전포 카페 거리").summary("전포 카페 거리는..").count(200).averageRating((float)4.3).address(addresses.get(5)).file(files.get(7)).build()
+                Place.builder().name("정문토스트").summary("정문토스트는..").count(100).averageRating((float)4.4).address(addresses.get(0)).file(files.get(0)).placeType(PlaceType.RESTAURANT).build(),
+                Place.builder().name("명물토스트").summary("명물토스트는..").count(200).averageRating((float)4.2).address(addresses.get(1)).file(files.get(1)).placeType(PlaceType.RESTAURANT).build(),
+                Place.builder().name("2023 부산 국제 락 페스티벌").summary("부락페는..").count(300).averageRating((float)4.3).address(addresses.get(2)).file(files.get(3)).placeType(PlaceType.FESTIVAL).build(),
+                Place.builder().name("2023 대동제").summary("대동제는..").count(200).averageRating((float)4.0).address(addresses.get(0)).file(files.get(3)).placeType(PlaceType.FESTIVAL).build(),
+                Place.builder().name("Signiel Busan").summary("부산 시그니엘은..").count(100).averageRating((float)4.5).address(addresses.get(4)).file(files.get(6)).placeType(PlaceType.TOURIST_SPOT).build(),
+                Place.builder().name("전포 카페 거리").summary("전포 카페 거리는..").count(200).averageRating((float)4.3).address(addresses.get(5)).file(files.get(7)).placeType(PlaceType.TOURIST_SPOT).build()
         );
         placeRepository.saveAll(places);
 

--- a/src/main/java/com/example/tripKo/domain/food/dto/response/FoodDetailsResponse.java
+++ b/src/main/java/com/example/tripKo/domain/food/dto/response/FoodDetailsResponse.java
@@ -37,6 +37,7 @@ public class FoodDetailsResponse {
         private String name;
         private String location;
         private float averageRating;
+        private String restaurantImage;
     }
 
     public FoodDetailsResponse(Food food) {
@@ -67,13 +68,7 @@ public class FoodDetailsResponse {
                 .name(foodHasPlaceRestaurants.getPlaceRestaurant().getPlace().getName())
                 .location(foodHasPlaceRestaurants.getPlaceRestaurant().getPlace().getAddress().toString())
                 .averageRating(foodHasPlaceRestaurants.getPlaceRestaurant().getPlace().getAverageRating())
+                .restaurantImage(foodHasPlaceRestaurants.getPlaceRestaurant().getPlace().getFile().getName())
                 .build();
-    }
-
-    private String addressToString(Address address) {
-        String addressToString = address.getBuildingName() + " " + address.getRoadName();
-        AddressCategory addressCategory = address.getAddressCategory();
-        String addressCategoryToString = addressCategory.getEmdName() + " " + addressCategory.getSiggName() + " " + addressCategory.getSidoName();
-        return addressToString + " " + addressCategoryToString;
     }
 }

--- a/src/main/java/com/example/tripKo/domain/place/api/ReviewController.java
+++ b/src/main/java/com/example/tripKo/domain/place/api/ReviewController.java
@@ -33,9 +33,9 @@ public class ReviewController {
         return ResponseEntity.ok(apiResult);
     }
 
-    @GetMapping("/restaurant/reviews/{placeRestaurantId}")
-    public ResponseEntity<?> getPlaceRestaurantReviews(@PathVariable Long placeRestaurantId, @RequestParam(value = "page", defaultValue = "0") Integer page) {
-        ReviewsResponse response = reviewService.getPlaceRestaurantReviewsByPlaceRestaurantId(placeRestaurantId, page);
+    @GetMapping("/restaurant/reviews/{placeId}")
+    public ResponseEntity<?> getPlaceRestaurantReviews(@PathVariable Long placeId, @RequestParam(value = "page", defaultValue = "0") Integer page) {
+        ReviewsResponse response = reviewService.getPlaceRestaurantReviewsByPlaceId(placeId, page);
         ApiUtils.ApiResult<?> apiResult = ApiUtils.success(response);
         return ResponseEntity.ok(apiResult);
     }

--- a/src/main/java/com/example/tripKo/domain/place/api/ReviewController.java
+++ b/src/main/java/com/example/tripKo/domain/place/api/ReviewController.java
@@ -4,6 +4,7 @@ import com.example.tripKo._core.errors.exception.Exception404;
 import com.example.tripKo._core.utils.ApiUtils;
 import com.example.tripKo.domain.member.dao.MemberRepository;
 import com.example.tripKo.domain.member.entity.Member;
+import com.example.tripKo.domain.place.PlaceType;
 import com.example.tripKo.domain.place.application.ReviewService;
 import com.example.tripKo.domain.place.dto.request.ReviewUpdateRequest;
 import com.example.tripKo.domain.place.dto.response.review.ReviewUpdateResponse;
@@ -28,29 +29,66 @@ public class ReviewController {
         Member member = memberRepository.findById(reviewRequest.getMemberId()).orElseThrow(() -> new Exception404("해당 id를 가진 회원을 찾을 수 없습니다: " + reviewRequest.getMemberId()));
         //Member member = userDetails.getMember()
 
-        reviewService.createPlaceRestaurantReview(reviewRequest, member);
+        reviewService.createPlaceReview(reviewRequest, PlaceType.RESTAURANT, member);
         ApiUtils.ApiResult<?> apiResult = ApiUtils.success(null);
         return ResponseEntity.ok(apiResult);
     }
 
     @GetMapping("/restaurant/reviews/{placeId}")
     public ResponseEntity<?> getPlaceRestaurantReviews(@PathVariable Long placeId, @RequestParam(value = "page", defaultValue = "0") Integer page) {
-        ReviewsResponse response = reviewService.getPlaceRestaurantReviewsByPlaceId(placeId, page);
+        ReviewsResponse response = reviewService.getReviewsByPlaceId(placeId, PlaceType.RESTAURANT, page);
         ApiUtils.ApiResult<?> apiResult = ApiUtils.success(response);
         return ResponseEntity.ok(apiResult);
     }
 
     @PatchMapping(path="/restaurant/reviews/{reviewId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<?> updatePlaceRestaurantReviews(@PathVariable Long reviewId, @ModelAttribute @Valid ReviewUpdateRequest reviewUpdateRequest) {
-        ReviewUpdateResponse reviewUpdateResponse = reviewService.updatePlaceRestaurantReview(reviewId, reviewUpdateRequest);
+        ReviewUpdateResponse reviewUpdateResponse = reviewService.updateReview(reviewId, reviewUpdateRequest);
         ApiUtils.ApiResult<?> apiResult = ApiUtils.success(reviewUpdateResponse);
         return ResponseEntity.ok(apiResult);
     }
 
     @DeleteMapping("/restaurant/reviews/{reviewId}")
     public ResponseEntity<?> deletePlaceRestaurantReviews(@PathVariable Long reviewId) {
-        reviewService.deletePlaceRestaurantReview(reviewId);
+        reviewService.deleteReview(reviewId);
         ApiUtils.ApiResult<?> apiResult = ApiUtils.success(null);
         return ResponseEntity.ok(apiResult);
+    }
+
+    /*
+    Festival
+    */
+    @PostMapping(path ="/festival/reviews", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<?> createFestivalReview(/*@AuthenticationPrincipal MyUserDetails userDetails, */ @ModelAttribute @Valid ReviewRequest reviewRequest) {
+        //Spring Security 개발되면 삭제
+        //원래 userDetails에서 Member를 가져오므로 현재 userDetails에서 Member를 가져왔다고 가정합니다.
+        Member member = memberRepository.findById(reviewRequest.getMemberId()).orElseThrow(() -> new Exception404("해당 id를 가진 회원을 찾을 수 없습니다: " + reviewRequest.getMemberId()));
+        //Member member = userDetails.getMember()
+
+        reviewService.createPlaceReview(reviewRequest, PlaceType.FESTIVAL, member);
+        ApiUtils.ApiResult<?> apiResult = ApiUtils.success(null);
+        return ResponseEntity.ok(apiResult);
+    }
+
+    @GetMapping("/festival/reviews/{placeId}")
+    public ResponseEntity<?> getFestivalReviews(@PathVariable Long placeId, @RequestParam(value = "page", defaultValue = "0") Integer page) {
+        ReviewsResponse response = reviewService.getReviewsByPlaceId(placeId, PlaceType.FESTIVAL, page);
+        ApiUtils.ApiResult<?> apiResult = ApiUtils.success(response);
+        return ResponseEntity.ok(apiResult);
+    }
+
+    @PatchMapping(path="/festival/reviews/{reviewId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<?> updateFestivalReviews(@PathVariable Long reviewId, @ModelAttribute @Valid ReviewUpdateRequest reviewUpdateRequest) {
+        ReviewUpdateResponse reviewUpdateResponse = reviewService.updateReview(reviewId, reviewUpdateRequest);
+        ApiUtils.ApiResult<?> apiResult = ApiUtils.success(reviewUpdateResponse);
+        return ResponseEntity.ok(apiResult);
+    }
+
+    @DeleteMapping("/festival/reviews/{reviewId}")
+    public ResponseEntity<?> deleteFestivalReviews(@PathVariable Long reviewId) {
+        reviewService.deleteReview(reviewId);
+        ApiUtils.ApiResult<?> apiResult = ApiUtils.success(null);
+        return ResponseEntity.ok(apiResult);
+
     }
 }

--- a/src/main/java/com/example/tripKo/domain/place/dao/ReviewRepository.java
+++ b/src/main/java/com/example/tripKo/domain/place/dao/ReviewRepository.java
@@ -1,6 +1,7 @@
 package com.example.tripKo.domain.place.dao;
 
 import com.example.tripKo.domain.member.entity.Member;
+import com.example.tripKo.domain.place.PlaceType;
 import com.example.tripKo.domain.place.entity.Place;
 import com.example.tripKo.domain.place.entity.Review;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/example/tripKo/domain/place/dto/request/ReviewRequest.java
+++ b/src/main/java/com/example/tripKo/domain/place/dto/request/ReviewRequest.java
@@ -1,11 +1,6 @@
 package com.example.tripKo.domain.place.dto.request;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
 

--- a/src/main/java/com/example/tripKo/domain/place/dto/response/info/RestaurantResponse.java
+++ b/src/main/java/com/example/tripKo/domain/place/dto/response/info/RestaurantResponse.java
@@ -65,7 +65,7 @@ public class RestaurantResponse {
             .collect(Collectors.toList()))
         .averageScore(placeRestaurant.getPlace().getAverageRating())
         .address(placeRestaurant.getPlace().addressToString(placeRestaurant.getPlace().getAddress()))
-        .holidayDate(placeRestaurant.getHolidayDate())
+        .holiday(placeRestaurant.getHoliday())
         .open(placeRestaurant.getOpeningTime() + "~" + placeRestaurant.getClosingTime())
         .breakTime(placeRestaurant.getBreakStartTime() + "~" + placeRestaurant.getBreakEndTime())
         .contactInfo(placeRestaurant.getContact_info())

--- a/src/main/java/com/example/tripKo/domain/place/dto/response/review/ReviewsResponse.java
+++ b/src/main/java/com/example/tripKo/domain/place/dto/response/review/ReviewsResponse.java
@@ -2,7 +2,6 @@ package com.example.tripKo.domain.place.dto.response.review;
 
 import com.example.tripKo.domain.place.entity.Place;
 import com.example.tripKo.domain.place.entity.Review;
-import com.example.tripKo.domain.place.entity.ReviewHasFile;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/com/example/tripKo/domain/place/entity/Place.java
+++ b/src/main/java/com/example/tripKo/domain/place/entity/Place.java
@@ -5,6 +5,8 @@ import com.example.tripKo.domain.file.entity.File;
 import com.example.tripKo.domain.member.entity.MemberReservationInfo;
 import java.util.ArrayList;
 import java.util.List;
+
+import com.example.tripKo.domain.place.PlaceType;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -51,14 +53,17 @@ public class Place extends BaseTimeEntity {
 
     private int reviewNumbers;
 
+    private PlaceType placeType;
+
     @Builder
-    public Place(String name, String summary, int count, float averageRating, File file, Address address) {
+    public Place(String name, String summary, int count, float averageRating, File file, Address address, PlaceType placeType) {
         this.name = name;
         this.summary = summary;
         this.count = count;
         this.averageRating = averageRating;
         this.file = file;
         this.address = address;
+        this.placeType = placeType;
     }
 
     public void addContents(Contents contents) {

--- a/src/main/java/com/example/tripKo/domain/place/entity/Review.java
+++ b/src/main/java/com/example/tripKo/domain/place/entity/Review.java
@@ -60,9 +60,9 @@ public class Review {
     private List<ReviewHasFile> reviewHasFiles = new ArrayList<>();
 
     @Builder
-    public Review(PlaceRestaurant placeRestaurant, Member member, String description, int score) {
+    public Review(Place place, Member member, String description, int score) {
         this.type = PlaceType.RESTAURANT;
-        this.place = placeRestaurant.getPlace();
+        this.place = place;
         this.member = member;
         this.description = description;
         this.score = score;


### PR DESCRIPTION
## 수행한 작업
- 음식 상세 정보 기능에서 음식과 연결된 식당의 이미지를 함께 출력하도록 변경
- 리뷰에서 플레이스의 id는 Restaurant, Festival의 id가 아닌 Place의 id를 받게 수정
- Festival 리뷰 CRUD 개발

## 전하고 싶은 내용
식당과 축제의 리뷰 기능에서 Request도 동일하고 Response도 동일하게 해달라는 프론트의 요청이 있었어요.
그래서 고민을 해봤는데 입력과 결과가 동일한데 서비스 내에 새로운 메서드를 만드는 것은 비효율적이라 생각해서 기존 PlaceRestaurant만 받았던 리뷰 CRUD 메서드를 모든 카테고리 다 받을 수 있도록 수정하였습니다. 

 이렇게 되면 다른 기능이 동일한 DTO를 공유하는 문제점이 있을 것 같은데 현재 결과값도 같고 각 카테고리는 동일한 리뷰 엔티티를 사용하기 때문에 DTO를 굳이 나눌 필요가 없다고 생각했었어요. 또한 로직은 완전히 동일하고 리턴하는 DTO만 달라진다면 코드는 똑같지만 리턴값만 달라지는 메서드를 또 추가해야 하는 문제가 있어서 이렇게 개발했습니다. 근데 개발하면서 이렇게 해도 되나? 싶긴 하네요... 혹시 의견 있으시면 남겨주세요!