### PR TITLE
Refactor : 리뷰 파일 삭제 로직 변경

### DIFF
--- a/src/main/java/com/example/tripKo/domain/place/api/ReviewController.java
+++ b/src/main/java/com/example/tripKo/domain/place/api/ReviewController.java
@@ -121,10 +121,9 @@ public class ReviewController {
     }
 
     @DeleteMapping("/touristSpot/reviews/{reviewId}")
-    public ResponseEntity<?> deleteTouristSpotReviews(@PathVariable Long reviewId) {
+    public ResponseEntity<Void> deleteTouristSpotReviews(@PathVariable Long reviewId) {
         reviewService.deleteReview(reviewId);
-        ApiUtils.ApiResult<?> apiResult = ApiUtils.success(null);
-        return ResponseEntity.ok(apiResult);
+        return ResponseEntity.noContent().build();
 
     }
 }

--- a/src/main/java/com/example/tripKo/domain/place/application/ReviewService.java
+++ b/src/main/java/com/example/tripKo/domain/place/application/ReviewService.java
@@ -149,11 +149,6 @@ public class ReviewService {
         place.setReviewNumbers(reviewNumbers - 1);
         place.setAverageRating(average);
 
-        List<ReviewHasFile> reviewFiles = review.getReviewHasFiles();
-        for (ReviewHasFile reviewFile : reviewFiles) {
-            fileRepository.delete(reviewFile.getFile());
-        }
-
         reviewRepository.deleteById(reviewId);
     }
 

--- a/src/main/java/com/example/tripKo/domain/place/application/ReviewService.java
+++ b/src/main/java/com/example/tripKo/domain/place/application/ReviewService.java
@@ -15,6 +15,7 @@ import com.example.tripKo.domain.place.dto.response.review.ReviewsResponse;
 import com.example.tripKo.domain.place.entity.Place;
 import com.example.tripKo.domain.place.entity.Review;
 import com.example.tripKo.domain.place.entity.ReviewHasFile;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -139,11 +140,7 @@ public class ReviewService {
     public void deleteReview(Long reviewId) {
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new Exception404("해당하는 리뷰를 찾을 수 없습니다. id : " + reviewId));
-
-        deleteImages(reviewId);
-
-        //평균 별점 업데이트
-        Place place = review.getPlace();
+        Place place = placeRepository.findById(review.getPlace().getId()).orElseThrow();
 
         int reviewNumbers = place.getReviewNumbers();
         float average = place.getAverageRating();
@@ -151,6 +148,11 @@ public class ReviewService {
         average = ((float) average * reviewNumbers - review.getScore()) / (reviewNumbers - 1);
         place.setReviewNumbers(reviewNumbers - 1);
         place.setAverageRating(average);
+
+        List<ReviewHasFile> reviewFiles = review.getReviewHasFiles();
+        for (ReviewHasFile reviewFile : reviewFiles) {
+            fileRepository.delete(reviewFile.getFile());
+        }
 
         reviewRepository.deleteById(reviewId);
     }

--- a/src/main/java/com/example/tripKo/domain/place/entity/Review.java
+++ b/src/main/java/com/example/tripKo/domain/place/entity/Review.java
@@ -16,6 +16,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
+import static javax.persistence.CascadeType.REMOVE;
 import static lombok.AccessLevel.PROTECTED;
 import static javax.persistence.GenerationType.IDENTITY;
 import static javax.persistence.FetchType.LAZY;
@@ -56,11 +57,11 @@ public class Review {
     @Column(nullable = false)
     private PlaceType type;
 
-    @OneToMany(mappedBy = "review")
+    @OneToMany(mappedBy = "review", cascade = REMOVE)
     private List<ReviewHasFile> reviewHasFiles = new ArrayList<>();
 
     @Builder
-    public Review(Place place, Member member, String description, int score) {
+    public Review(PlaceType placeType, Place place, Member member, String description, int score) {
         this.type = PlaceType.RESTAURANT;
         this.place = place;
         this.member = member;

--- a/src/main/java/com/example/tripKo/domain/place/entity/ReviewHasFile.java
+++ b/src/main/java/com/example/tripKo/domain/place/entity/ReviewHasFile.java
@@ -9,6 +9,7 @@ import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.*;
 
+import static javax.persistence.CascadeType.REMOVE;
 import static lombok.AccessLevel.PROTECTED;
 import static javax.persistence.GenerationType.IDENTITY;
 import static javax.persistence.FetchType.LAZY;
@@ -29,7 +30,7 @@ public class ReviewHasFile {
     @JoinColumn(name = "review_id", nullable = false)
     private Review review;
 
-    @OneToOne(fetch = LAZY)
+    @OneToOne(fetch = LAZY, cascade = REMOVE)
     @JoinColumn(name = "file_id", nullable = false)
     private File file;
 


### PR DESCRIPTION
## 수행한 일
- 리뷰 파일 삭제 로직을 변경했습니다.
    - `deleteImage`를 사용하지 않고, `cascade`를 이용하여 리뷰 삭제 시 해당 리뷰 파일도 함께 삭제되도록 변경
    
## 기타
- 리뷰 이미지에 대한 부분을 리팩토링하려고 생각만 하다가 이제 하게 되었네요ㅠㅠ
- 리뷰 삭제 담당자 @enchantee00  님이 추가적으로 하면 좋은 것들 입니당
    - 평균 별점 서비스 로직 제대로 작동하는 지 확인 (평균 별점 바뀌는 부분은 수정하지 않았습니다! 꼭 따로 확인해주세요)
    - 알아보기 쉽도록 메서드 분리 (평균 별점 계산하는 부분은 메서드 분리해도 좋을 것 같아요)
    - 관련된 다른 api 수정해보기
- 추가적으로 할 만한 코드 수정도 있는데, 일단 저는 과제가 있어서.. 과제하러 갑니당.... 다음에 시간나면 또 리팩토링 해보겠습니당