### PR TITLE
Fix : 회원가입 유효성 검사 수정

### DIFF
--- a/src/main/java/com/example/tripKo/domain/member/api/MemberController.java
+++ b/src/main/java/com/example/tripKo/domain/member/api/MemberController.java
@@ -55,7 +55,7 @@ public class MemberController {
   }
 
   @PostMapping("/register")
-  public ResponseEntity<Void> signUp(@RequestBody SignUpRequest request) {
+  public ResponseEntity<Void> signUp(@RequestBody @Valid SignUpRequest request) {
     memberService.signUp(request.getMemberId(), request.getPassword(), request.getNickName(), request.getRealName(),
         request.getEmail(), request.getNationality());
     return ResponseEntity.status(HttpStatus.CREATED).build();

--- a/src/test/java/com/example/tripKo/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/com/example/tripKo/domain/member/api/MemberControllerTest.java
@@ -24,13 +24,13 @@ public class MemberControllerTest extends IntegrationTest {
       SignUpRequest request = SignUpRequest.builder()
           .memberId("tripko123")
           .password("tripko1234!")
-          .nickName("트립코")
+          .nickName("트립코트립코")
           .realName("김철수")
           .email("tripko@tripko.com")
           .nationality("한국")
           .build();
 
-      mockMvc.perform(post("/sign-up")
+      mockMvc.perform(post("/register")
               .content(objectMapper.writeValueAsString(request))
               .contentType(MediaType.APPLICATION_JSON))
           .andExpect(status().isCreated())
@@ -38,5 +38,94 @@ public class MemberControllerTest extends IntegrationTest {
           .andDo(document);
     }
 
+    @Test
+    @DisplayName("유효하지 않은 아이디면 테스트는 실패한다.")
+    public void fail_signUp_invalidId() throws Exception {
+      SignUpRequest request = SignUpRequest.builder()
+          .memberId("3")
+          .password("tripko1234!")
+          .nickName("트립코트립코")
+          .realName("김철수")
+          .email("tripko@tripko.com")
+          .nationality("한국")
+          .build();
+
+      mockMvc.perform(post("/register")
+              .content(objectMapper.writeValueAsString(request))
+              .contentType(MediaType.APPLICATION_JSON))
+          .andExpect(status().is5xxServerError());
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 비밀번호라면 테스트는 실패한다.")
+    public void fail_signUp_invalidPassword() throws Exception {
+      SignUpRequest request = SignUpRequest.builder()
+          .memberId("tripko123")
+          .password("tripko1234")
+          .nickName("트립코트립코")
+          .realName("김철수")
+          .email("tripko@tripko.com")
+          .nationality("한국")
+          .build();
+
+      mockMvc.perform(post("/register")
+              .content(objectMapper.writeValueAsString(request))
+              .contentType(MediaType.APPLICATION_JSON))
+          .andExpect(status().is5xxServerError());
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 닉네임이라면 테스트는 실패한다.")
+    public void fail_signUp_invalidNickname() throws Exception {
+      SignUpRequest request = SignUpRequest.builder()
+          .memberId("tripko123")
+          .password("tripko1234!")
+          .nickName("트립코")
+          .realName("김철수")
+          .email("tripko@tripko.com")
+          .nationality("한국")
+          .build();
+
+      mockMvc.perform(post("/register")
+              .content(objectMapper.writeValueAsString(request))
+              .contentType(MediaType.APPLICATION_JSON))
+          .andExpect(status().is5xxServerError());
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 이름 테스트는 실패한다.")
+    public void fail_signUp_invalidRealName() throws Exception {
+      SignUpRequest request = SignUpRequest.builder()
+          .memberId("tripko123")
+          .password("tripko1234!")
+          .nickName("트립코트립코")
+          .realName("김철수1")
+          .email("tripko@tripko.com")
+          .nationality("한국")
+          .build();
+
+      mockMvc.perform(post("/register")
+              .content(objectMapper.writeValueAsString(request))
+              .contentType(MediaType.APPLICATION_JSON))
+          .andExpect(status().is5xxServerError());
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 이메일 양식이라면 테스트는 실패한다.")
+    public void fail_signUp_invalidEmail() throws Exception {
+      SignUpRequest request = SignUpRequest.builder()
+          .memberId("tripko123")
+          .password("tripko1234!")
+          .nickName("트립코트립코")
+          .realName("김철수")
+          .email("tripkotripko.com")
+          .nationality("한국")
+          .build();
+
+      mockMvc.perform(post("/register")
+              .content(objectMapper.writeValueAsString(request))
+              .contentType(MediaType.APPLICATION_JSON))
+          .andExpect(status().is5xxServerError());
+    }
   }
 }


### PR DESCRIPTION
## 수행한 일
- 적용되지 않고 있던 회원가입 유효성 검사를 적용되도록 변경하였습니다.
- 그에 대한 테스트 내역도 작성하였습니다.

저희는 다음과 같은 회원가입 조건이 필요합니다. (테스트 할때 참고하세용)
- 로그인 아이디는 6~20자 영어, 숫자만 가능
- 비밀번호는 8~16자여야 하고 영어, 숫자, 특수문자가 포함되어야 함
- 이름은 1~30자 한글, 영어만 가능
- 닉네임은 6~20자 한글, 영어만 가능
- 이메일은 이메일 양식을 지켜야 함