### PR TITLE
feat: 리프레쉬토큰 주석 해제 및 만료시 헤더 교체

### DIFF
--- a/src/main/java/com/example/tripKo/_core/security/JwtProvider.java
+++ b/src/main/java/com/example/tripKo/_core/security/JwtProvider.java
@@ -7,6 +7,8 @@ import com.example.tripKo._core.security.data.JwtToken;
 import static com.example.tripKo._core.security.data.JwtType.ACCESS_TOKEN;
 import static com.example.tripKo._core.security.data.JwtType.REFRESH_TOKEN;
 
+import com.example.tripKo._core.security.data.RefreshToken;
+import com.example.tripKo._core.utils.RedisUtil;
 import com.example.tripKo.domain.member.MemberRoleType;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
@@ -32,6 +34,7 @@ import java.util.stream.Collectors;
 public class JwtProvider {
 
   private final JwtUserDetailsService jwtUserDetailsService;
+  private final RedisUtil redisUtil;
 
   private static final String ROLES = "roles";
   private static final String SEPARATOR = ",";
@@ -58,7 +61,7 @@ public class JwtProvider {
     String refreshToken = createRefreshToken();
 
     //redis 설치 필요
-//        redisUtil.save(new RefreshToken(userPK, refreshToken));
+    redisUtil.save(new RefreshToken(userPK, refreshToken));
 
     return JwtToken.builder()
         .grantType("Bearer ")

--- a/src/main/java/com/example/tripKo/_core/security/SecurityConfig.java
+++ b/src/main/java/com/example/tripKo/_core/security/SecurityConfig.java
@@ -73,7 +73,7 @@ public class SecurityConfig {
           FilterResponseUtils.forbidden(response, new Exception403("권한이 없습니다"));
         }))
         .and()
-        .addFilterBefore(new JwtAuthFilter(jwtProvider, redisUtil), UsernamePasswordAuthenticationFilter.class)
+        .addFilterBefore(new JwtAuthFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
         .addFilterBefore(new RefreshTokenFilter(jwtProvider, redisUtil), JwtAuthFilter.class);
 
 

--- a/src/main/java/com/example/tripKo/_core/security/filter/JwtAuthFilter.java
+++ b/src/main/java/com/example/tripKo/_core/security/filter/JwtAuthFilter.java
@@ -20,7 +20,6 @@ import org.springframework.web.filter.GenericFilterBean;
 public class JwtAuthFilter extends GenericFilterBean {
 
   private final JwtProvider jwtProvider;
-  private final RedisUtil redisUtil;
 
   @Override
   public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)

--- a/src/main/java/com/example/tripKo/_core/security/filter/RefreshTokenFilter.java
+++ b/src/main/java/com/example/tripKo/_core/security/filter/RefreshTokenFilter.java
@@ -12,7 +12,10 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.GenericFilterBean;
@@ -42,6 +45,10 @@ public class RefreshTokenFilter extends GenericFilterBean {
         String newAccessToken = jwtProvider.createAccessToken(id);
         Authentication authentication = jwtProvider.getAuthentication(newAccessToken);
         SecurityContextHolder.getContext().setAuthentication(authentication);
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+        httpResponse.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + newAccessToken);
+      } else if (isAccessTokenExpired && !isAccessExpiredAndRefreshValid) {
+        SecurityContextHolder.getContext().setAuthentication(null);
       }
     }
     chain.doFilter(request, response);


### PR DESCRIPTION
## 수행한 일
- 리프레쉬토큰 주석 해제
- 만료시 액세스토큰 재발급해서 response 해더에 날리기
- 만약 리프레쉬토큰에 문제가 있으면 context 비우기
